### PR TITLE
Use composited animations

### DIFF
--- a/dev/snowflakes.css
+++ b/dev/snowflakes.css
@@ -7,11 +7,11 @@
 
 @keyframes snowflakes-fall {
   0% {
-    top: -10%;
+    transform: translateY(0vh)
   }
 
   100% {
-    top: 100%;
+    transform: translateY(110vh)
   }
 }
 
@@ -38,57 +38,113 @@
     user-select:none;
     cursor:default;
 
-    animation-name: snowflakes-fall, snowflakes-shake;
-    animation-duration: 10s, 3s;
-    animation-timing-function: linear, ease-in-out;
-    animation-iteration-count: infinite, infinite;
-    animation-play-state: running, running;
+    animation-name: snowflakes-shake;
+    animation-duration: 3s;
+    animation-timing-function: ease-in-out;
+    animation-iteration-count: infinite;
+    animation-play-state: running;
 }
+
+.snowflake .inner {
+    animation-duration: 10s;
+    animation-iteration-count: infinite;
+    animation-name: snowflakes-fall;
+    animation-play-state: running;
+    animation-timing-function: linear;
+}
+
 .snowflake:nth-of-type(0) {
     left: 1%;
-    animation-delay: 0s, 0s;
+    animation-delay: 0s;
 }
+.snowflake:nth-of-type(0) .inner {
+    animation-delay: 0s;
+}
+
 .snowflake:nth-of-type(1) {
     left: 10%;
-    animation-delay: 1s, 1s;
+    animation-delay: 1s;
 }
+.snowflake:nth-of-type(1) .inner {
+    animation-delay: 1s;
+}
+
 .snowflake:nth-of-type(2) {
     left: 20%;
-    animation-delay: 6s, 0.5s;
+    animation-delay: 0.5s;
 }
+.snowflake:nth-of-type(2) .inner {
+    animation-delay: 6s;
+}
+
 .snowflake:nth-of-type(3) {
     left: 30%;
-    animation-delay: 4s, 2s;
+    animation-delay: 2s;
 }
+.snowflake:nth-of-type(3) .inner {
+    animation-delay: 4s;
+}
+
 .snowflake:nth-of-type(4) {
     left: 40%;
-    animation-delay: 2s, 2s;
+    animation-delay: 2s;
 }
+.snowflake:nth-of-type(4) .inner {
+    animation-delay: 2s;
+}
+
 .snowflake:nth-of-type(5) {
     left: 50%;
-    animation-delay: 8s, 3s;
+    animation-delay: 3s;
 }
+.snowflake:nth-of-type(5) .inner {
+    animation-delay: 8s;
+}
+
 .snowflake:nth-of-type(6) {
     left: 60%;
-    animation-delay: 6s, 2s;
+    animation-delay: 2s;
 }
+.snowflake:nth-of-type(6) .inner {
+    animation-delay: 6s;
+}
+
 .snowflake:nth-of-type(7) {
     left: 70%;
-    animation-delay: 2.5s, 1s;
+    animation-delay: 1s;
 }
+.snowflake:nth-of-type(7) .inner {
+    animation-delay: 2.5s;
+}
+
 .snowflake:nth-of-type(8) {
     left: 80%;
-    animation-delay: 1s, 0s;
+    animation-delay: 0s;
 }
+.snowflake:nth-of-type(8) .inner {
+    animation-delay: 1s;
+}
+
 .snowflake:nth-of-type(9) {
     left: 90%;
-    animation-delay: 3s, 1.5s;
+    animation-delay: 1.5s;
 }
+.snowflake:nth-of-type(9) .inner {
+    animation-delay: 3s;
+}
+
 .snowflake:nth-of-type(10) {
     left: 25%;
-    animation-delay: 2s, 0s;
+    animation-delay: 0s;
 }
+.snowflake:nth-of-type(10) .inner {
+    animation-delay: 2s;
+}
+
 .snowflake:nth-of-type(11) {
     left: 65%;
-    animation-delay: 4s, 2.5s;
+    animation-delay: 2.5s;
+}
+.snowflake:nth-of-type(11) .inner {
+    animation-delay: 4s;
 }

--- a/dev/snowflakes.css
+++ b/dev/snowflakes.css
@@ -7,16 +7,16 @@
 
 @keyframes snowflakes-fall {
   0% {
-    transform: translateY(0vh)
+    transform: translateY(0vh);
   }
 
   100% {
-    transform: translateY(110vh)
+    transform: translateY(110vh);
   }
 }
 
 @keyframes snowflakes-shake {
-  0%{
+  0% {
     transform: translateX(0px);
   }
 
@@ -30,121 +30,121 @@
 }
 
 .snowflake {
-    position: fixed;
-    top: -10%;
-    z-index: 9999;
-    /* still needed for Safari */
-    -webkit-user-select:none;
-    user-select:none;
-    cursor:default;
+  position: fixed;
+  top: -10%;
+  z-index: 9999;
+  /* still needed for Safari */
+  -webkit-user-select: none;
+  user-select: none;
+  cursor: default;
 
-    animation-name: snowflakes-shake;
-    animation-duration: 3s;
-    animation-timing-function: ease-in-out;
-    animation-iteration-count: infinite;
-    animation-play-state: running;
+  animation-name: snowflakes-shake;
+  animation-duration: 3s;
+  animation-timing-function: ease-in-out;
+  animation-iteration-count: infinite;
+  animation-play-state: running;
 }
 
 .snowflake .inner {
-    animation-duration: 10s;
-    animation-iteration-count: infinite;
-    animation-name: snowflakes-fall;
-    animation-play-state: running;
-    animation-timing-function: linear;
+  animation-duration: 10s;
+  animation-iteration-count: infinite;
+  animation-name: snowflakes-fall;
+  animation-play-state: running;
+  animation-timing-function: linear;
 }
 
 .snowflake:nth-of-type(0) {
-    left: 1%;
-    animation-delay: 0s;
+  left: 1%;
+  animation-delay: 0s;
 }
 .snowflake:nth-of-type(0) .inner {
-    animation-delay: 0s;
+  animation-delay: 0s;
 }
 
 .snowflake:nth-of-type(1) {
-    left: 10%;
-    animation-delay: 1s;
+  left: 10%;
+  animation-delay: 1s;
 }
 .snowflake:nth-of-type(1) .inner {
-    animation-delay: 1s;
+  animation-delay: 1s;
 }
 
 .snowflake:nth-of-type(2) {
-    left: 20%;
-    animation-delay: 0.5s;
+  left: 20%;
+  animation-delay: 0.5s;
 }
 .snowflake:nth-of-type(2) .inner {
-    animation-delay: 6s;
+  animation-delay: 6s;
 }
 
 .snowflake:nth-of-type(3) {
-    left: 30%;
-    animation-delay: 2s;
+  left: 30%;
+  animation-delay: 2s;
 }
 .snowflake:nth-of-type(3) .inner {
-    animation-delay: 4s;
+  animation-delay: 4s;
 }
 
 .snowflake:nth-of-type(4) {
-    left: 40%;
-    animation-delay: 2s;
+  left: 40%;
+  animation-delay: 2s;
 }
 .snowflake:nth-of-type(4) .inner {
-    animation-delay: 2s;
+  animation-delay: 2s;
 }
 
 .snowflake:nth-of-type(5) {
-    left: 50%;
-    animation-delay: 3s;
+  left: 50%;
+  animation-delay: 3s;
 }
 .snowflake:nth-of-type(5) .inner {
-    animation-delay: 8s;
+  animation-delay: 8s;
 }
 
 .snowflake:nth-of-type(6) {
-    left: 60%;
-    animation-delay: 2s;
+  left: 60%;
+  animation-delay: 2s;
 }
 .snowflake:nth-of-type(6) .inner {
-    animation-delay: 6s;
+  animation-delay: 6s;
 }
 
 .snowflake:nth-of-type(7) {
-    left: 70%;
-    animation-delay: 1s;
+  left: 70%;
+  animation-delay: 1s;
 }
 .snowflake:nth-of-type(7) .inner {
-    animation-delay: 2.5s;
+  animation-delay: 2.5s;
 }
 
 .snowflake:nth-of-type(8) {
-    left: 80%;
-    animation-delay: 0s;
+  left: 80%;
+  animation-delay: 0s;
 }
 .snowflake:nth-of-type(8) .inner {
-    animation-delay: 1s;
+  animation-delay: 1s;
 }
 
 .snowflake:nth-of-type(9) {
-    left: 90%;
-    animation-delay: 1.5s;
+  left: 90%;
+  animation-delay: 1.5s;
 }
 .snowflake:nth-of-type(9) .inner {
-    animation-delay: 3s;
+  animation-delay: 3s;
 }
 
 .snowflake:nth-of-type(10) {
-    left: 25%;
-    animation-delay: 0s;
+  left: 25%;
+  animation-delay: 0s;
 }
 .snowflake:nth-of-type(10) .inner {
-    animation-delay: 2s;
+  animation-delay: 2s;
 }
 
 .snowflake:nth-of-type(11) {
-    left: 65%;
-    animation-delay: 2.5s;
+  left: 65%;
+  animation-delay: 2.5s;
 }
 .snowflake:nth-of-type(11) .inner {
-    animation-delay: 4s;
+  animation-delay: 4s;
 }

--- a/dev/snowflakes.html
+++ b/dev/snowflakes.html
@@ -1,38 +1,38 @@
 <div class="snowflakes" aria-hidden="true">
   <div class="snowflake">
-    ❅
+    <div class="inner">❅</div>
   </div>
   <div class="snowflake">
-    ❆
+    <div class="inner">❅</div>
   </div>
   <div class="snowflake">
-    ❅
+    <div class="inner">❅</div>
   </div>
   <div class="snowflake">
-    ❆
+    <div class="inner">❅</div>
   </div>
   <div class="snowflake">
-    ❅
+    <div class="inner">❅</div>
   </div>
   <div class="snowflake">
-    ❆
+    <div class="inner">❅</div>
   </div>
   <div class="snowflake">
-    ❅
+    <div class="inner">❅</div>
   </div>
   <div class="snowflake">
-    ❆
+    <div class="inner">❅</div>
   </div>
   <div class="snowflake">
-    ❅
+    <div class="inner">❅</div>
   </div>
   <div class="snowflake">
-    ❆
+    <div class="inner">❅</div>
   </div>
   <div class="snowflake">
-    ❅
+    <div class="inner">❅</div>
   </div>
   <div class="snowflake">
-    ❆
+    <div class="inner">❅</div>
   </div>
 </div>

--- a/snippet.html
+++ b/snippet.html
@@ -7,43 +7,43 @@
   text-shadow: 0 0 5px #000;
 }
 
-@keyframes snowflakes-fall{0%{top:-10%}100%{top:100%}}@keyframes snowflakes-shake{0%,100%{transform:translateX(0)}50%{transform:translateX(80px)}}.snowflake{position:fixed;top:-10%;z-index:9999;-webkit-user-select:none;user-select:none;cursor:default;animation-name:snowflakes-fall,snowflakes-shake;animation-duration:10s,3s;animation-timing-function:linear,ease-in-out;animation-iteration-count:infinite,infinite;animation-play-state:running,running}.snowflake:nth-of-type(0){left:1%;animation-delay:0s,0s}.snowflake:first-of-type{left:10%;animation-delay:1s,1s}.snowflake:nth-of-type(2){left:20%;animation-delay:6s,.5s}.snowflake:nth-of-type(3){left:30%;animation-delay:4s,2s}.snowflake:nth-of-type(4){left:40%;animation-delay:2s,2s}.snowflake:nth-of-type(5){left:50%;animation-delay:8s,3s}.snowflake:nth-of-type(6){left:60%;animation-delay:6s,2s}.snowflake:nth-of-type(7){left:70%;animation-delay:2.5s,1s}.snowflake:nth-of-type(8){left:80%;animation-delay:1s,0s}.snowflake:nth-of-type(9){left:90%;animation-delay:3s,1.5s}.snowflake:nth-of-type(10){left:25%;animation-delay:2s,0s}.snowflake:nth-of-type(11){left:65%;animation-delay:4s,2.5s}
+.snowflake,.snowflake .inner{animation-iteration-count:infinite;animation-play-state:running}@keyframes snowflakes-fall{0%{transform:translateY(0)}100%{transform:translateY(110vh)}}@keyframes snowflakes-shake{0%,100%{transform:translateX(0)}50%{transform:translateX(80px)}}.snowflake{position:fixed;top:-10%;z-index:9999;-webkit-user-select:none;user-select:none;cursor:default;animation-name:snowflakes-shake;animation-duration:3s;animation-timing-function:ease-in-out}.snowflake .inner{animation-duration:10s;animation-name:snowflakes-fall;animation-timing-function:linear}.snowflake:nth-of-type(0){left:1%;animation-delay:0s}.snowflake:nth-of-type(0) .inner{animation-delay:0s}.snowflake:first-of-type{left:10%;animation-delay:1s}.snowflake:first-of-type .inner,.snowflake:nth-of-type(8) .inner{animation-delay:1s}.snowflake:nth-of-type(2){left:20%;animation-delay:.5s}.snowflake:nth-of-type(2) .inner,.snowflake:nth-of-type(6) .inner{animation-delay:6s}.snowflake:nth-of-type(3){left:30%;animation-delay:2s}.snowflake:nth-of-type(11) .inner,.snowflake:nth-of-type(3) .inner{animation-delay:4s}.snowflake:nth-of-type(4){left:40%;animation-delay:2s}.snowflake:nth-of-type(10) .inner,.snowflake:nth-of-type(4) .inner{animation-delay:2s}.snowflake:nth-of-type(5){left:50%;animation-delay:3s}.snowflake:nth-of-type(5) .inner{animation-delay:8s}.snowflake:nth-of-type(6){left:60%;animation-delay:2s}.snowflake:nth-of-type(7){left:70%;animation-delay:1s}.snowflake:nth-of-type(7) .inner{animation-delay:2.5s}.snowflake:nth-of-type(8){left:80%;animation-delay:0s}.snowflake:nth-of-type(9){left:90%;animation-delay:1.5s}.snowflake:nth-of-type(9) .inner{animation-delay:3s}.snowflake:nth-of-type(10){left:25%;animation-delay:0s}.snowflake:nth-of-type(11){left:65%;animation-delay:2.5s}
 </style>
 <div class="snowflakes" aria-hidden="true">
   <div class="snowflake">
-  ❅
+    <div class="inner">❅</div>
   </div>
   <div class="snowflake">
-  ❆
+    <div class="inner">❅</div>
   </div>
   <div class="snowflake">
-  ❅
+    <div class="inner">❅</div>
   </div>
   <div class="snowflake">
-  ❆
+    <div class="inner">❅</div>
   </div>
   <div class="snowflake">
-  ❅
+    <div class="inner">❅</div>
   </div>
   <div class="snowflake">
-  ❆
+    <div class="inner">❅</div>
   </div>
   <div class="snowflake">
-    ❅
+    <div class="inner">❅</div>
   </div>
   <div class="snowflake">
-    ❆
+    <div class="inner">❅</div>
   </div>
   <div class="snowflake">
-    ❅
+    <div class="inner">❅</div>
   </div>
   <div class="snowflake">
-    ❆
+    <div class="inner">❅</div>
   </div>
   <div class="snowflake">
-    ❅
+    <div class="inner">❅</div>
   </div>
   <div class="snowflake">
-    ❆
+    <div class="inner">❅</div>
   </div>
 </div>


### PR DESCRIPTION
Reduces layout and style recalculations.

As pointed out by https://github.com/pajasevi/CSSnowflakes/issues/2
and browser best practices:
- https://developer.chrome.com/docs/lighthouse/performance/non-composited-animations/
- https://web.dev/articles/stick-to-compositor-only-properties-and-manage-layer-count

NB @pajasevi : This PR includes ~the commit of https://github.com/pajasevi/CSSnowflakes/pull/4 and~ a cleanup commit.
If those are merged, I am willing to update the GitHub page too if you want